### PR TITLE
chore(ng-router-store): add angular 14 to peer dependencies

### DIFF
--- a/libs/ng-router-store/package.json
+++ b/libs/ng-router-store/package.json
@@ -20,8 +20,8 @@
     "typescript"
   ],
   "peerDependencies": {
-    "@angular/common": "^13.0.0",
-    "@angular/core": "^13.0.0",
+    "@angular/common": "^13.0.0 || ^14.0.0",
+    "@angular/core": "^13.0.0 || ^14.0.0",
     "@ngneat/elf": "*",
     "@ngneat/elf-devtools": "^1.2.0"
   },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/elf-ng-router-store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe:
  - Updating peer dependency
```

## What is the current behavior?

Currently, when running `npm i @ngneat/elf-ng-router-store` in an Angular 14 project, npm complains with:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: elf-router@0.0.0
npm ERR! Found: @angular/common@14.2.0
npm ERR! node_modules/@angular/common
npm ERR!   @angular/common@"^14.1.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @angular/common@"^13.0.0" from @ngneat/elf-ng-router-store@1.0.5
npm ERR! node_modules/@ngneat/elf-ng-router-store
npm ERR!   @ngneat/elf-ng-router-store@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

So one has to run `npm i @ngneat/elf-ng-router-store --legacy-peer-deps` to install this library.

## What is the new behavior?

`npm i @ngneat/elf-ng-router-store`  just works in an Angular 14 project.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

We're using `@ngneat/elf-ng-router-store` successfully in an Angular 14 project, so I'm assuming there are no other changes necessary to make this library work with Angular 14, but I'm not 100% sure.